### PR TITLE
Fix bug in hashing function for 32bit primality test

### DIFF
--- a/src/nt_funcs.rs
+++ b/src/nt_funcs.rs
@@ -1043,6 +1043,11 @@ mod tests {
             assert_eq!(SMALL_PRIMES.contains(&x), is_prime64(x as u64));
         }
         assert!(is_prime64(677));
+        
+        // from PR #7
+        assert!(!is_prime64(9773));
+        assert!(!is_prime64(13357));
+        assert!(!is_prime64(18769));
 
         // some large primes
         assert!(is_prime64(6469693333));

--- a/src/nt_funcs.rs
+++ b/src/nt_funcs.rs
@@ -94,7 +94,7 @@ pub fn is_prime64(target: u64) -> bool {
 }
 
 fn is_prime32_miller(target: u32) -> bool {
-    let h = target;
+    let h = target as u64;
     let h = ((h >> 16) ^ h).wrapping_mul(0x45d9f3b);
     let h = ((h >> 16) ^ h).wrapping_mul(0x45d9f3b);
     let h = ((h >> 16) ^ h) & 255;


### PR DESCRIPTION
The hash function used in Forišek & Jančina uses 64 bits internally. Currently, there are 2075 composites incorrectly classified as prime by `is_prime32_miller` (eg 9773, 13357, 18769). Adding a cast to `u64` gets rid of all misclassifications.
Repro code (uses `primal` to generate primes):
```rust
use num_prime::nt_funcs::is_prime64;
use primal::Primes;

fn main() {
    const LIMIT: usize = u32::MAX as usize;

    let mut primes = Primes::all();
    let mut miss_count = 0;
    let mut p = primes.next().unwrap();
    for n in 1..=LIMIT {
        let expected = if n == p {
            p = primes.next().unwrap();
            true
        } else {
            false
        };
        let actual = is_prime64(n as u64);
        if expected != actual {
            miss_count += 1;
            println!("{} {} {}", expected, actual, n);
        }
    }

    println!("{}", miss_count);
}
```