### PR TITLE
Update lru dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ num-traits = "0.2.14"
 num-modular = "0.5.0"
 bitvec = "1.0.0"
 rand = "0.8.4"
-lru = "0.7.2"
+lru = "0.12.2"
 either = "1.6.1"
 
 [dependencies.num-bigint]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -24,6 +24,7 @@ use lru::LruCache;
 use num_integer::Roots;
 use rand::random;
 use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 
 /// Extension functions that can utilize pre-generated primes
 pub trait PrimeBufferExt: for<'a> PrimeBuffer<'a> {
@@ -454,7 +455,8 @@ impl NaiveBuffer {
         let b = self.prime_pi(b);
         let c = self.prime_pi(c);
 
-        let mut phi_cache = LruCache::new(a as usize);
+        let cache_cap = NonZeroUsize::new(if a != 0 { a as usize } else { 1 }).expect("Always > 0");
+        let mut phi_cache = LruCache::new(cache_cap);
         let mut sum =
             self.prime_phi(limit, a as usize, &mut phi_cache) + (b + a - 2) * (b - a + 1) / 2;
         for i in a + 1..b + 1 {


### PR DESCRIPTION
Because of a change to the `stdsimd` nightly feature, num-prime is currently broken on nightly, as it depends on an old version of `ahash`
```
ahash v0.7.7
└── hashbrown v0.12.3
    └── lru v0.7.8
        └── num-prime v0.4.3
```
which uses automatic nightly detection and enables the now removed `stdsimd` feature (see https://github.com/tkaitchuck/aHash/issues/200). This issue is fixed in a new version of `ahash` which is now transitively used by the updated dependency on lru.