### PR TITLE
Fixing broken tests on aarch64 targets

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -13,12 +13,15 @@ num-bigint = "0.4"
 num-prime = { path = ".." }
 criterion = "0.3"
 rand = "0.8"
-
 num-primes = { version = "0.3.0", optional = true }
 primal-check = "0.3.1"
-number-theory = "0.0.6"
 is_prime = "2.0.7"
 glass_pumpkin = "1.2.0"
 
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+number-theory = "0.0.6"
+
 [features]
 default = ["num-primes"]
+
+

--- a/bench/benches/bench.rs
+++ b/bench/benches/bench.rs
@@ -8,6 +8,8 @@ use num_bigint::RandBigInt;
 use num_prime::{nt_funcs, RandPrime};
 #[cfg(feature = "num-primes")]
 use num_primes::{Generator, Verification};
+
+#[cfg(target_arch = "x86_64")]
 use number_theory::NumberTheory;
 use primal_check::miller_rabin;
 
@@ -24,9 +26,12 @@ pub fn bench_is_prime(c: &mut Criterion) {
     group.bench_function("num-prime (this crate)", |b| {
         b.iter(|| numbers().filter(|&n| nt_funcs::is_prime64(n)).count())
     });
+
+    #[cfg(target_arch = "x86_64")]
     group.bench_function("number-theory", |b| {
         b.iter(|| numbers().filter(|&n| NumberTheory::is_prime(&n)).count())
     });
+
     #[cfg(feature = "num-primes")]
     group.bench_function("num-primes", |b| {
         b.iter(|| {
@@ -193,6 +198,8 @@ pub fn bench_factorization(c: &mut Criterion) {
                 .count()
         })
     });
+
+    #[cfg(target_arch = "x86_64")]
     group.bench_function("number-theory", |b| {
         b.iter(|| {
             numbers()


### PR DESCRIPTION
The number-theory crate was unable to build on aarch64. I made it an optional dependency depending on target.  I can add the benchmark build to the CI if you want to catch this going forward.