### PR TITLE
bench: use seeded RNG for glass_pumpkin prime generation benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,8 @@ dependencies = [
  "number-theory",
  "primal-check",
  "rand 0.8.5",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -784,7 +786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -796,6 +798,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.0",
 ]
 
 [[package]]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -14,6 +14,8 @@ num-bigint = { version = "0.4", features = ["rand"] }
 num-prime = { path = "..", features = ["big-int"] }
 criterion = { version = "4.3.0", package = "codspeed-criterion-compat" }
 rand = "0.8"
+rand_chacha = "0.10"
+rand_core = "0.10"
 num-primes = { version = "0.3.0", optional = true }
 primal-check = "0.3.1"
 is_prime = "2.0.7"
@@ -24,5 +26,3 @@ number-theory = "0.0.6"
 
 [features]
 default = ["num-primes"]
-
-


### PR DESCRIPTION
Use glass_pumpkin's from_rng() API with a seeded ChaCha8Rng instead of new() which uses OsRng internally, making these benchmarks deterministic. num-primes doesn't expose an RNG parameter so it remains non-deterministic.